### PR TITLE
Added option to overwrite default FlexibleContainer

### DIFF
--- a/sources/lib/Command/GenerateEntity.php
+++ b/sources/lib/Command/GenerateEntity.php
@@ -71,7 +71,8 @@ HELP
             $this->schema,
             $this->relation,
             $this->filename,
-            $this->namespace
+            $this->namespace,
+            $this->flexible_container
         ))->generate($input, $output);
     }
 }

--- a/sources/lib/Command/GenerateForRelation.php
+++ b/sources/lib/Command/GenerateForRelation.php
@@ -86,7 +86,8 @@ class GenerateForRelation extends RelationAwareCommand
                 $this->schema,
                 $this->relation,
                 $filename,
-                $this->getNamespace($input->getArgument('config-name'))
+                $this->getNamespace($input->getArgument('config-name')),
+                $this->flexible_container
             ))->generate($input, $output);
         } elseif ($output->isVerbose()) {
             $this->writelnSkipFile($output, $filename, 'entity');

--- a/sources/lib/Command/GenerateForSchema.php
+++ b/sources/lib/Command/GenerateForSchema.php
@@ -77,7 +77,8 @@ class GenerateForSchema extends SchemaAwareCommand
                 '--bootstrap-file' => $input->getOption('bootstrap-file'),
                 '--prefix-dir'     => $input->getOption('prefix-dir'),
                 '--prefix-ns'      => $input->getOption('prefix-ns'),
-                ];
+                '--flexible-container' => $input->getOption('flexible-container')
+            ];
             $command->run(new ArrayInput($arguments), $output);
         }
     }

--- a/sources/lib/Command/SchemaAwareCommand.php
+++ b/sources/lib/Command/SchemaAwareCommand.php
@@ -37,6 +37,7 @@ abstract class SchemaAwareCommand extends PommAwareCommand
     protected $prefix_ns;
     protected $filename;
     protected $namespace;
+    protected $flexible_container;
 
     /**
      * configure
@@ -80,7 +81,14 @@ abstract class SchemaAwareCommand extends PommAwareCommand
                 'Schema of the relation.',
                 'public'
             )
-            ;
+            ->addOption(
+                'flexible-container',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Use an alternative flexible entity container',
+                'PommProject\ModelManager\Model\FlexibleEntity'
+            )
+        ;
 
         return $this;
     }
@@ -100,6 +108,7 @@ abstract class SchemaAwareCommand extends PommAwareCommand
 
         $this->prefix_dir = $input->getOption('prefix-dir');
         $this->prefix_ns  = $input->getOption('prefix-ns');
+        $this->flexible_container = $input->getOption('flexible-container');
     }
 
     /**

--- a/sources/lib/Generator/BaseGenerator.php
+++ b/sources/lib/Generator/BaseGenerator.php
@@ -36,6 +36,7 @@ abstract class BaseGenerator
     protected $relation;
     protected $filename;
     protected $namespace;
+    protected $flexibe_container;
 
     /*
      * __construct
@@ -49,13 +50,14 @@ abstract class BaseGenerator
      * @param  string  $namespace
      * @return void
      */
-    public function __construct(Session $session, $schema, $relation, $filename, $namespace)
+    public function __construct(Session $session, $schema, $relation, $filename, $namespace, $flexible_container = null)
     {
         $this->session   = $session;
         $this->schema    = $schema;
         $this->relation  = $relation;
         $this->filename  = $filename;
         $this->namespace = $namespace;
+        $this->flexibe_container = $flexible_container;
     }
 
     /**

--- a/sources/lib/Generator/EntityGenerator.php
+++ b/sources/lib/Generator/EntityGenerator.php
@@ -51,6 +51,8 @@ class EntityGenerator extends BaseGenerator
                     'entity'    => Inflector::studlyCaps($this->relation),
                     'relation'  => $this->relation,
                     'schema'    => $this->schema,
+                    'flexible_container' => $this->flexibe_container,
+                    'flexible_container_class' => array_reverse(explode('\\', $this->flexibe_container))[0]
                 ]
             )
         );
@@ -68,7 +70,7 @@ class EntityGenerator extends BaseGenerator
 
 namespace {:namespace:};
 
-use PommProject\ModelManager\Model\FlexibleEntity;
+use {:flexible_container:};
 
 /**
  * {:entity:}
@@ -78,7 +80,7 @@ use PommProject\ModelManager\Model\FlexibleEntity;
  *
  * @see FlexibleEntity
  */
-class {:entity:} extends FlexibleEntity
+class {:entity:} extends {:flexible_container_class:}
 {
 }
 

--- a/sources/tests/Fixture/CustomAlphaEntity.php
+++ b/sources/tests/Fixture/CustomAlphaEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Model\PommTest\PommTestSchema;
+
+use Model\PommTest\PommTestSchema\CustomFlexibleEntity;
+
+/**
+ * Alpha
+ *
+ * Flexible entity for relation
+ * pomm_test.alpha
+ *
+ * @see FlexibleEntity
+ */
+class Alpha extends CustomFlexibleEntity
+{
+}

--- a/sources/tests/Unit/Command/GenerateEntity.php
+++ b/sources/tests/Unit/Command/GenerateEntity.php
@@ -47,7 +47,7 @@ class GenerateEntity extends FoundationSessionAtoum
                 'schema'           => 'pomm_test',
                 'relation'         => 'alpha',
                 '--prefix-ns'      => 'Model',
-                '--prefix-dir'     => 'tmp',
+                '--prefix-dir'     => 'tmp'
             ];
         $tester = new CommandTester($command);
         $tester->execute($command_args);
@@ -66,5 +66,13 @@ class GenerateEntity extends FoundationSessionAtoum
             ->string($tester->getDisplay())
             ->isEqualTo(" ✓  Overwriting file 'tmp/Model/PommTest/PommTestSchema/Alpha.php'.\n")
          ;
+
+        $tester->execute(array_merge($command_args, ['--flexible-container' => 'Model\\PommTest\\PommTestSchema\\CustomFlexibleEntity', '--force' => null ]));
+        $this
+            ->string(file_get_contents('tmp/Model/PommTest/PommTestSchema/Alpha.php'))
+            ->isEqualTo(file_get_contents('sources/tests/Fixture/CustomAlphaEntity.php'))
+        ;
+
+
     }
 }


### PR DESCRIPTION
I've added an option to use another flexible container with the cli command tool

```sh
% ./bin/pomm.php help  pomm:generate:entity 
Usage:
 pomm:generate:entity [-d|--prefix-dir="..."] [-a|--prefix-ns="..."] [-b|--bootstrap-file="..."] [--flexible-container="..."] [--force] config-name relation [schema]

Options:
 --flexible-container  Use an alternative flexible entity container (default: "PommProject\\ModelManager\\Model\\FlexibleEntity")
...
```