### PR TITLE
add path-pattern option

### DIFF
--- a/sources/lib/Command/GenerateEntity.php
+++ b/sources/lib/Command/GenerateEntity.php
@@ -72,6 +72,13 @@ HELP
                 InputOption::VALUE_NONE,
                 'Use PSR4 structure.'
             )
+            ->addOption(
+                'path-pattern',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Use a different directory pattern when generating classes.',
+                '{session}/{schema}Schema'
+            )
         ;
 
         return $this;
@@ -88,7 +95,14 @@ HELP
 
         $session = $this->mustBeModelManagerSession($this->getSession());
 
-        $this->pathFile = $this->getPathFile($input->getArgument('config-name'), $this->relation, '', '', $input->getOption('psr4'));
+        $this->pathFile = $this->getPathFile(
+            $input->getArgument('config-name'),
+            $this->relation,
+            '',
+            '',
+            $input->getOption('psr4'),
+            $input->getOption('path-pattern')
+        );
         $this->namespace = $this->getNamespace($input->getArgument('config-name'));
 
         $this->updateOutput(

--- a/sources/lib/Command/GenerateForRelation.php
+++ b/sources/lib/Command/GenerateForRelation.php
@@ -57,6 +57,13 @@ class GenerateForRelation extends RelationAwareCommand
                 InputOption::VALUE_NONE,
                 'Use PSR4 structure.'
             )
+            ->addOption(
+                'path-pattern',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Use a different directory pattern when generating classes.',
+                '{session}/{schema}Schema'
+            )
         ;
     }
 
@@ -77,12 +84,12 @@ class GenerateForRelation extends RelationAwareCommand
                 $session,
                 $this->schema,
                 $this->relation,
-                $this->getPathFile($input->getArgument('config-name'), $this->relation, null, 'AutoStructure', $input->getOption('psr4')),
+                $this->getPathFile($input->getArgument('config-name'), $this->relation, null, 'AutoStructure', $input->getOption('psr4'), $input->getOption('path-pattern')),
                 $this->getNamespace($input->getArgument('config-name'), 'AutoStructure')
             ))->generate(new ParameterHolder(array_merge($input->getArguments(), $input->getOptions())))
         );
 
-        $pathFile = $this->getPathFile($input->getArgument('config-name'), $this->relation, 'Model', '', $input->getOption('psr4'));
+        $pathFile = $this->getPathFile($input->getArgument('config-name'), $this->relation, 'Model', '', $input->getOption('psr4'), $input->getOption('path-pattern'));
         if (!file_exists($pathFile) || $input->getOption('force')) {
             $this->updateOutput(
                 $output,
@@ -98,7 +105,7 @@ class GenerateForRelation extends RelationAwareCommand
             $this->writelnSkipFile($output, $pathFile, 'model');
         }
 
-        $pathFile = $this->getPathFile($input->getArgument('config-name'), $this->relation, '', '', $input->getOption('psr4'));
+        $pathFile = $this->getPathFile($input->getArgument('config-name'), $this->relation, '', '', $input->getOption('psr4'), $input->getOption('path-pattern'));
         if (!file_exists($pathFile) || $input->getOption('force')) {
             $this->updateOutput(
                 $output,

--- a/sources/lib/Command/GenerateForSchema.php
+++ b/sources/lib/Command/GenerateForSchema.php
@@ -54,6 +54,13 @@ class GenerateForSchema extends SchemaAwareCommand
                 InputOption::VALUE_NONE,
                 'Use PSR4 structure.'
             )
+            ->addOption(
+                'path-pattern',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Use a different directory pattern when generating classes.',
+                '{session}/{schema}Schema'
+            )
         ;
     }
 
@@ -92,6 +99,7 @@ class GenerateForSchema extends SchemaAwareCommand
                     '--bootstrap-file' => $input->getOption('bootstrap-file'),
                     '--prefix-dir'     => $input->getOption('prefix-dir'),
                     '--prefix-ns'      => $input->getOption('prefix-ns'),
+                    '--path-pattern'   => $input->getOption('path-pattern'),
                     '--flexible-container' => $input->getOption('flexible-container'),
                     '--psr4'           => $input->getOption('psr4')
                 ];

--- a/sources/lib/Command/GenerateRelationModel.php
+++ b/sources/lib/Command/GenerateRelationModel.php
@@ -54,6 +54,13 @@ class GenerateRelationModel extends RelationAwareCommand
                 InputOption::VALUE_NONE,
                 'Use PSR4 structure.'
             )
+            ->addOption(
+                'path-pattern',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Use a different directory pattern when generating classes.',
+                '{session}/{schema}Schema'
+            )
         ;
     }
 
@@ -68,7 +75,14 @@ class GenerateRelationModel extends RelationAwareCommand
 
         $session = $this->mustBeModelManagerSession($this->getSession());
 
-        $this->pathFile  = $this->getPathFile($input->getArgument('config-name'), $this->relation, 'Model', '', $input->getOption('psr4'));
+        $this->pathFile  = $this->getPathFile(
+            $input->getArgument('config-name'),
+            $this->relation,
+            'Model',
+            '',
+            $input->getOption('psr4'),
+            $input->getOption('path-pattern')
+        );
         $this->namespace = $this->getNamespace($input->getArgument('config-name'));
 
         $this->updateOutput(

--- a/sources/lib/Command/GenerateRelationStructure.php
+++ b/sources/lib/Command/GenerateRelationStructure.php
@@ -51,6 +51,13 @@ HELP
                 InputOption::VALUE_NONE,
                 'Use PSR4 structure.'
             )
+            ->addOption(
+                'path-pattern',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Use a different directory pattern when generating classes.',
+                '{session}/{schema}Schema'
+            )
         ;
     }
 
@@ -65,7 +72,14 @@ HELP
 
         $session = $this->mustBeModelManagerSession($this->getSession());
 
-        $this->pathFile = $this->getPathFile($input->getArgument('config-name'), $this->relation, null, 'AutoStructure', $input->getOption('psr4'));
+        $this->pathFile = $this->getPathFile(
+            $input->getArgument('config-name'),
+            $this->relation,
+            null,
+            'AutoStructure',
+            $input->getOption('psr4'),
+            $input->getOption('path-pattern')
+        );
         $this->namespace = $this->getNamespace($input->getArgument('config-name'), 'AutoStructure');
 
         $this->updateOutput(

--- a/sources/lib/Command/SchemaAwareCommand.php
+++ b/sources/lib/Command/SchemaAwareCommand.php
@@ -122,7 +122,14 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
      * @param  bool   $format_psr4
      * @return string
      */
-    protected function getPathFile($config_name, $file_name, $file_suffix = '', $extra_dir = '', $format_psr4 = null)
+    protected function getPathFile(
+        $config_name,
+        $file_name,
+        $file_suffix = '',
+        $extra_dir = '',
+        $format_psr4 = null,
+        $path_pattern = '{session}/{schema}Schema'
+    )
     {
         $format_psr4 = $format_psr4 === null ? false : (bool) $format_psr4;
         $prefix_ns = "";
@@ -135,8 +142,7 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
             [
                 rtrim($this->prefix_dir, '/'),
                 $prefix_ns,
-                Inflector::studlyCaps($config_name),
-                Inflector::studlyCaps(sprintf("%s_schema", $this->schema)),
+                $this->expandPath($path_pattern),
                 $extra_dir,
                 sprintf("%s%s.php", Inflector::studlyCaps($file_name), $file_suffix)
             ];
@@ -144,6 +150,26 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
         return join('/', array_filter($elements, function ($val) {
             return $val != null;
         }));
+    }
+
+    /**
+     * expandPath
+     *
+     * Expand path pattern with the context values
+     *
+     * @param   string $pattern
+     * @return  string
+     */
+    protected function expandPath($pattern)
+    {
+        return trim(
+            strtr(
+                $pattern,
+                [
+                    '{session}' => Inflector::studlyCaps($this->config_name),
+                    '{schema}'  => Inflector::studlyCaps($this->schema),
+                ]),
+        '/');
     }
 
     /**

--- a/sources/lib/Command/SchemaAwareCommand.php
+++ b/sources/lib/Command/SchemaAwareCommand.php
@@ -129,8 +129,8 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
         $extra_dir = '',
         $format_psr4 = null,
         $path_pattern = '{session}/{schema}Schema'
-    )
-    {
+    ) {
+    
         $format_psr4 = $format_psr4 === null ? false : (bool) $format_psr4;
         $prefix_ns = "";
 
@@ -168,8 +168,10 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
                 [
                     '{session}' => Inflector::studlyCaps($this->config_name),
                     '{schema}'  => Inflector::studlyCaps($this->schema),
-                ]),
-        '/');
+                ]
+            ),
+            '/'
+        );
     }
 
     /**

--- a/sources/tests/Unit/Command/GenerateEntity.php
+++ b/sources/tests/Unit/Command/GenerateEntity.php
@@ -80,5 +80,10 @@ class GenerateEntity extends ModelSessionAtoum
             ->string(file_get_contents('tmp/Model/PommTest/PommTestSchema/Alpha.php'))
             ->isEqualTo(file_get_contents('sources/tests/Fixture/AlphaEntity.php'))
         ;
+        $tester->execute(array_merge($command_args, ['--psr4' => null, '--path-pattern' => '{session}Session/Schema{schema}']), $options);
+        $this
+            ->string($tester->getDisplay())
+            ->isEqualTo(" ✓  Creating file 'tmp/Model/PommTestSession/SchemaPommTest/Alpha.php'.".PHP_EOL)
+            ;
     }
 }

--- a/sources/tests/Unit/Command/GenerateRelationModel.php
+++ b/sources/tests/Unit/Command/GenerateRelationModel.php
@@ -97,5 +97,10 @@ class GenerateRelationModel extends ModelSessionAtoum
             ->string(file_get_contents('tmp/Model/PommTest/PommTestSchema/BetaModel.php'))
             ->isEqualTo(file_get_contents('sources/tests/Fixture/BetaModel.php'))
         ;
+        $tester->execute(array_merge($command_args, ['--psr4' => null, '--path-pattern' => '{session}Session/Schema{schema}']), $options);
+        $this
+            ->string($tester->getDisplay())
+            ->isEqualTo(" ✓  Creating file 'tmp/Model/PommTestSession/SchemaPommTest/BetaModel.php'.".PHP_EOL)
+            ;
     }
 }

--- a/sources/tests/Unit/Command/GenerateRelationStructure.php
+++ b/sources/tests/Unit/Command/GenerateRelationStructure.php
@@ -70,5 +70,10 @@ class GenerateRelationStructure extends ModelSessionAtoum
             ->string(file_get_contents('tmp/Model/PommTest/PommTestSchema/AutoStructure/Beta.php'))
             ->isEqualTo(file_get_contents('sources/tests/Fixture/BetaStructure.php'))
             ;
+        $tester->execute(array_merge($command_args, ['--psr4' => null, '--path-pattern' => '{session}Session/Schema{schema}']), $options);
+        $this
+            ->string($tester->getDisplay())
+            ->isEqualTo(" ✓  Creating file 'tmp/Model/PommTestSession/SchemaPommTest/AutoStructure/Beta.php'.".PHP_EOL)
+            ;
     }
 }


### PR DESCRIPTION
This allows users to change the `Session/SchemaSchema` path pattern when generating files for the Model Manager.

close #31 