### PR TITLE
Add --no-default-namespace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,15 @@ $ ./bin/pomm.php pomm:generate:schema-all --prefix-dir sources/lib --prefix-ns M
  ✓  Creating file 'sources/lib/Model/PommTest/PublicSchema/AutoStructure/Pika.php'.
 …
 ```
+
+Also, Cli automatically adds config and schema names to the namespace of generated classes.
+In the example above it's `PommTest\PublicSchema`.
+Since Pomm does not require that part of the namespace it can be removed by using `--no-default-namespace` option.
+This can be helpful if you store all data in one schema and you don't want to have schema name in namespace.
+Please be careful, in this case it's possible to have overlaps if relations in different schemas have same name.
+
+```
+$ ./bin/pomm.php pomm:generate:schema-all --prefix-dir sources/lib --prefix-ns Model --no-default-namespace pomm_test
+ ✓  Creating file 'sources/lib/Model/AutoStructure/Pika.php'.
+…
+```

--- a/sources/lib/Command/GenerateForSchema.php
+++ b/sources/lib/Command/GenerateForSchema.php
@@ -94,6 +94,7 @@ class GenerateForSchema extends SchemaAwareCommand
                     '--prefix-dir'     => $input->getOption('prefix-dir'),
                     '--prefix-ns'      => $input->getOption('prefix-ns'),
                     '--flexible-container' => $input->getOption('flexible-container'),
+                    '--no-default-namespace' => $input->getOption('no-default-namespace'),
                     '--psr4'           => $input->getOption('psr4')
                 ];
                 $command->run(new ArrayInput($arguments), $output);

--- a/sources/lib/Command/SchemaAwareCommand.php
+++ b/sources/lib/Command/SchemaAwareCommand.php
@@ -37,6 +37,7 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
     protected $pathFile;
     protected $namespace;
     protected $flexible_container;
+    protected $default_namespace;
 
     /**
      * configure
@@ -86,6 +87,12 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
                 'Use an alternative flexible entity container',
                 'PommProject\ModelManager\Model\FlexibleEntity'
             )
+            ->addOption(
+                'no-default-namespace',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not include config and schema name to the generated namespace.'
+            )
         ;
 
         return $this;
@@ -107,6 +114,7 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
         $this->prefix_dir = $input->getOption('prefix-dir');
         $this->prefix_ns  = $input->getOption('prefix-ns');
         $this->flexible_container = $input->getOption('flexible-container');
+        $this->default_namespace = !$input->getOption('no-default-namespace');
     }
 
     /**
@@ -135,8 +143,8 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
             [
                 rtrim($this->prefix_dir, '/'),
                 $prefix_ns,
-                Inflector::studlyCaps($config_name),
-                Inflector::studlyCaps(sprintf("%s_schema", $this->schema)),
+                $this->default_namespace ? Inflector::studlyCaps($config_name) : null,
+                $this->default_namespace ? Inflector::studlyCaps(sprintf("%s_schema", $this->schema)) : null,
                 $extra_dir,
                 sprintf("%s%s.php", Inflector::studlyCaps($file_name), $file_suffix)
             ];
@@ -159,8 +167,8 @@ abstract class SchemaAwareCommand extends SessionAwareCommand
         $elements =
             [
                 $this->prefix_ns,
-                Inflector::studlyCaps($config_name),
-                Inflector::studlyCaps(sprintf("%s_schema", $this->schema)),
+                $this->default_namespace ? Inflector::studlyCaps($config_name) : null,
+                $this->default_namespace ? Inflector::studlyCaps(sprintf("%s_schema", $this->schema)) : null,
                 $extra_ns
             ];
 


### PR DESCRIPTION
Hello.

When generating classes Cli always adds config-name and schema to the namespace of generated classes.
Example from README:

```
$ ./bin/pomm.php pomm:generate:schema-all --prefix-dir sources/lib --prefix-ns Model pomm_test
 ✓  Creating file 'sources/lib/Model/PommTest/PublicSchema/AutoStructure/Pika.php'.
```

That part is `PommTest/PublicSchema`. For my tiny project this is ugly since I store all data in one schema and I have one Pomm config. So it would be great to remove that part. So in result we will have something like this:

```
$ ./bin/pomm.php pomm:generate:schema-all --prefix-dir sources/lib --prefix-ns Model --no-default-namespace pomm_test
 ✓  Creating file 'sources/lib/Model/AutoStructure/Pika.php'.
```

I don't dare to say that is a good way, but I think the developers should have a choice. That's why I've added new option `--no-default-namespace`. For me it works correctly, so I think it should be available for everyone. It does not change the default behaviour, so should not cause accidents.

Cheers!